### PR TITLE
Add `pluginPath` param to `Initialize` method

### DIFF
--- a/MengeCS/MengeCS.csproj
+++ b/MengeCS/MengeCS.csproj
@@ -50,14 +50,13 @@
     <Compile Include="Vector2.cs" />
     <Compile Include="Vector3.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="MengeCore.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy /y /d "$(MengeDir)\MengeCore.dll" $(ProjectDir)</PreBuildEvent>
+    <PreBuildEvent>if "$(ConfigurationName)" == "Debug" (
+  xcopy /y /d "$(MengeDir)\MengeCore_d.dll" $(TargetDir)
+) ELSE (
+  xcopy /y /d "$(MengeDir)\MengeCore.dll" $(TargetDir)
+)</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MengeCS/Simulator.cs
+++ b/MengeCS/Simulator.cs
@@ -18,9 +18,9 @@ namespace MengeCS
             _agents = new List<Agent>();
         }
 
-        public bool Initialize(String behaveXml, String sceneXml, String model)
+        public bool Initialize(String behaveXml, String sceneXml, String model, String pluginPath = null)
         {
-            if (MengeWrapper.InitSimulator(behaveXml, sceneXml, model, null))
+            if (MengeWrapper.InitSimulator(behaveXml, sceneXml, model, pluginPath))
             {
                 FindTriggers();
                 uint count = MengeWrapper.AgentCount();

--- a/MengeCSExe/MengeCSExe.csproj
+++ b/MengeCSExe/MengeCSExe.csproj
@@ -49,13 +49,14 @@
       <Name>MengeCS</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\MengeCS\MengeCore.dll">
-      <Link>MengeCore.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>if "$(ConfigurationName)" == "Debug" (
+  xcopy /y /d "$(ProjectDir)..\MengeCS\bin\Debug\MengeCore_d.dll" $(TargetDir)
+) ELSE (
+  xcopy /y /d "$(ProjectDir)..\MengeCS\bin\Release\MengeCore.dll" $(TargetDir)
+)</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
The changes are:

1.  Add `pluginPath` param to `Initialize` method in `Simulator` class with default to `null`.
2.  Deleted the local copy of `MengeCore_d.dll` and enhanced the pre-build events to copy the dll that matches the build configuration from the external folder for both `MengeCS` and `MengeCSExe` projects.

This should also close issue #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mengecrowdsim/mengecs/8)
<!-- Reviewable:end -->
