### PR TITLE
Sourcing MengeCore dlls directly from Menge directory

### DIFF
--- a/MengeCS/MengeCS.csproj
+++ b/MengeCS/MengeCS.csproj
@@ -50,14 +50,13 @@
     <Compile Include="Vector2.cs" />
     <Compile Include="Vector3.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="MengeCore.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy /y /d "$(MengeDir)\MengeCore.dll" $(ProjectDir)</PreBuildEvent>
+    <PreBuildEvent>if "$(ConfigurationName)" == "Debug" (
+  xcopy /y /d "$(MengeDir)\MengeCore_d.dll" $(TargetDir)
+) ELSE (
+  xcopy /y /d "$(MengeDir)\MengeCore.dll" $(TargetDir)
+)</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MengeCS/MengeWrapper.cs
+++ b/MengeCS/MengeWrapper.cs
@@ -8,44 +8,50 @@ namespace MengeCS
 {
     class MengeWrapper
     {
-        [DllImport("MengeCore")]
+#if DEBUG
+        const string MENGE_DLL = "MengeCore_d";
+#else
+        const string MENGE_DLL = "MengeCore";
+#endif
+
+        [DllImport(MENGE_DLL)]
         public static extern bool InitSimulator([MarshalAs(UnmanagedType.LPStr)] String behaveFile,
                                                 [MarshalAs(UnmanagedType.LPStr)] String sceneFile,
                                                 [MarshalAs(UnmanagedType.LPStr)] String model,
                                                 [MarshalAs(UnmanagedType.LPStr)] String pluginPath
                                                 );
-        
-        [DllImport("MengeCore")]
+
+        [DllImport(MENGE_DLL)]
         public static extern float SetTimeStep(float timestep);
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern bool DoStep();
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern uint AgentCount();
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern bool GetAgentPosition(uint i, ref float x, ref float y, ref float z);
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern bool GetAgentVelocity(uint i, ref float x, ref float y, ref float z);
 
-        [DllImport("MengeCore")]
-        public static extern bool GetAgentOrient(uint i, ref float x, ref float y );
+        [DllImport(MENGE_DLL)]
+        public static extern bool GetAgentOrient(uint i, ref float x, ref float y);
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern int GetAgentClass(uint i);
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern float GetAgentRadius(uint i);
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern int ExternalTriggerCount();
 
-        [DllImport("MengeCore")]
+        [DllImport(MENGE_DLL)]
         public static extern IntPtr ExternalTriggerName(int i);
 
-        [DllImport("MengeCore", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(MENGE_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern void FireExternalTrigger([MarshalAs(UnmanagedType.LPStr)] string lpString);
     }
 }

--- a/MengeCSExe/MengeCSExe.csproj
+++ b/MengeCSExe/MengeCSExe.csproj
@@ -49,13 +49,14 @@
       <Name>MengeCS</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\MengeCS\MengeCore.dll">
-      <Link>MengeCore.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>if "$(ConfigurationName)" == "Debug" (
+  xcopy /y /d "$(ProjectDir)..\MengeCS\bin\Debug\MengeCore_d.dll" $(TargetDir)
+) ELSE (
+  xcopy /y /d "$(ProjectDir)..\MengeCS\bin\Release\MengeCore.dll" $(TargetDir)
+)</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
As per your suggestion in #8, this PR has only the changes to source the dll's from MengeCore directory which is configured in `MengeCS.csproj`.

I have also updated `MengeWrapper.cs` to pick the debug or release version of the dll as per the build configuration using preprocessor directives.

Please let me know if I got your suggestion right or whether further modifications are needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mengecrowdsim/mengecs/9)
<!-- Reviewable:end -->
